### PR TITLE
A temporary workarround for parallel find_if

### DIFF
--- a/examples/find_if.cpp
+++ b/examples/find_if.cpp
@@ -1,0 +1,49 @@
+#include <vector>
+#include <iostream>
+#include <chrono>
+#include <random>
+#include <experimental/algorithm>
+
+template<typename T, class UnaryPredicate, typename U>
+auto myfind(T && policy, const std::vector<U> & values, UnaryPredicate pred)
+  -> std::chrono::microseconds
+{
+	using namespace std;
+	using namespace std::experimental; 
+	
+	auto start = chrono::high_resolution_clock::now();
+	auto result = find_if(policy, begin(values), end(values), pred);
+	auto finish = chrono::high_resolution_clock::now();
+	
+	if (result != end(values)){	
+		cout << "Value found: " << *result << " at position: "
+		     << &(*result) - &(*begin(values)) << endl;
+	} else {
+		cout << "No such value found" << endl;
+	}
+	
+	return chrono::duration_cast<chrono::microseconds>(finish-start); 
+}
+
+int main()
+{
+	using namespace std;
+	
+	vector<int> values(5000000);
+	for (size_t i = 0; i < values.size(); i++){
+		values[i] = (int)i;
+	}
+	
+	auto pred = [](int a){
+		return false;
+		//return ((a+1)%43 == 0);
+	};
+	
+	cout << "Using seq:   " 
+	     << myfind(experimental::parallel::seq, values, pred).count() 
+	     << " us" << endl;
+	
+	cout << "Using par:   " 
+	     << myfind(experimental::parallel::par, values, pred).count() 
+	     << " us" << endl;
+}

--- a/include/experimental/bits/parallel/algos/par/find_if.h
+++ b/include/experimental/bits/parallel/algos/par/find_if.h
@@ -14,11 +14,12 @@ inline namespace v1 {
     InputIterator parallel_execution_policy::find_if(InputIterator first, InputIterator last,
                                                      Predicate pred) const 
   {
-    return detail::diffract_gather(first, last,
+    return detail::diffract_gather2(first, last,
                                    std::find_if<InputIterator, Predicate>,
-                                   [&](const InputIterator &a, const InputIterator &b){
-                                     return distance(first, a) < distance(first, b) ?
-                                            a : b;
+                                   last,
+                                   [&](const InputIterator &a, const InputIterator &b, auto subrange){
+                                     return ((distance(first, b) < distance(first, a)) && (b != std::get<1>(subrange))) ?
+                                            b : a;
                                    },
                                    pred);
 


### PR DESCRIPTION
- The new function `diffract_gather2` allows an extended collapse function,
  which also retrieves the subrange belonging to the current value as additional
  argument (a pair of iterators)
- `examples/find_if.cpp` - a stupidly simple example to test find_if - was added