### PR TITLE
Fixed unit test for reduce

### DIFF
--- a/test/alg.nonmodifying/alg.numerics.reduce/reduce.cpp
+++ b/test/alg.nonmodifying/alg.numerics.reduce/reduce.cpp
@@ -40,7 +40,7 @@ TEST(reduce, CustomNoInit){
     }
   };
   
-  // unititialized elements are 1, reduction should be 100
+  // unititialized elements are 1, reduction should be 101 (100 + init)
   const std::vector<Element> v(100);
 
   auto res = std::experimental::parallel::reduce(
@@ -49,7 +49,7 @@ TEST(reduce, CustomNoInit){
 #endif
                          std::begin(v), std::end(v));
 
-  EXPECT_EQ(100, res.value);
+  EXPECT_EQ(101, res.value);
 }
 
 
@@ -88,7 +88,7 @@ TEST(reduce, CustomNoInitEmptyRange){
                          std::begin(v), std::begin(v));
 
   // should return Element{0}
-  EXPECT_EQ(0, res.value);
+  EXPECT_EQ(1, res.value);
 }
 
 


### PR DESCRIPTION
I think the unit tests for reduce using the custom type aren't correct. I believe the result of an empty reduce without providing an initial value should return the value of the default constructor of the custom type. Also reduce over a non-empty collection of a custom type without providing a initial value should return the sum of that collection plus the value of the default constructor of the custom type.

I'm not totally sure if I read the specification correctly here, as this behavior is a bit counterintuitive (I would intuitively expect the sum of an empty collection to be 0, and a sum of 100 elements each having a value of 1 to be 100).

